### PR TITLE
Update URL for cfssl download

### DIFF
--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/gravitational/debian-grande:stretch
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends curl jq && \
-    curl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 -o /usr/local/bin/cfssl && \
-    curl  https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64 -o /usr/local/bin/cfssljson && \
+    curl --fail -L https://github.com/cloudflare/cfssl/releases/download/1.2.0/cfssl_linux-amd64 -o /usr/local/bin/cfssl && \
+    curl --fail -L https://github.com/cloudflare/cfssl/releases/download/1.2.0/cfssljson_linux-amd64 -o /usr/local/bin/cfssljson && \
     mkdir -p /root/cfssl
 
 ADD *.json /root/cfssl/


### PR DESCRIPTION
Previous URLs are silently responding with http 200 code which broke the whole package.